### PR TITLE
[sourcemation/rabbitmq-operator] Release 0.1.16

### DIFF
--- a/charts/rabbitmq-operator/Chart.yaml
+++ b/charts/rabbitmq-operator/Chart.yaml
@@ -33,4 +33,4 @@ name: rabbitmq-operator
 sources:
   - https://github.com/SourceMation/charts.git
 type: application
-version: 0.1.15
+version: 0.1.16

--- a/charts/rabbitmq-operator/README.md
+++ b/charts/rabbitmq-operator/README.md
@@ -42,7 +42,7 @@
 ```bash
 export RELEASE_NAME=rabbitmq-ope
 export CHART_NAME=rabbitmq-operator
-export CHART_VERSION=0.1.15
+export CHART_VERSION=0.1.16
 export RELEASE_NAMESPACE=lp-system
 
 kubectl create ns ${RELEASE_NAMESPACE}

--- a/charts/rabbitmq-operator/values.yaml
+++ b/charts/rabbitmq-operator/values.yaml
@@ -19,7 +19,7 @@ rke2rabbitmqope:
   rabbitmqImage:
     registry: docker.io
     repository: sourcemation/rabbitmq-4
-    tag: "4.1.3-20250820"
+    tag: "4.1.4-20250925"
     digest: ""
     pullSecrets: []
   #credentialUpdaterImage:
@@ -55,7 +55,7 @@ rke2rabbitmqope:
     image:
       registry: docker.io
       repository: sourcemation/rabbitmq-cluster-operator
-      tag: "2.16.1-20250821"
+      tag: "2.16.1-20250922"
       digest: ""
       pullPolicy: IfNotPresent
       pullSecrets: []


### PR DESCRIPTION
New release:
    * App version: 4.4.34
    * Chart version: 0.1.16
    * Immutable tags:
- sourcemation/rabbitmq-cluster-operator:2.16.1-20250922
- sourcemation/rabbitmq-4:4.1.4-20250925