### PR TITLE
[sourcemation/rabbitmq-operator] Release 0.1.17

### DIFF
--- a/charts/rabbitmq-operator/Chart.yaml
+++ b/charts/rabbitmq-operator/Chart.yaml
@@ -33,4 +33,4 @@ name: rabbitmq-operator
 sources:
   - https://github.com/SourceMation/charts.git
 type: application
-version: 0.1.16
+version: 0.1.17

--- a/charts/rabbitmq-operator/README.md
+++ b/charts/rabbitmq-operator/README.md
@@ -42,7 +42,7 @@
 ```bash
 export RELEASE_NAME=rabbitmq-ope
 export CHART_NAME=rabbitmq-operator
-export CHART_VERSION=0.1.16
+export CHART_VERSION=0.1.17
 export RELEASE_NAMESPACE=lp-system
 
 kubectl create ns ${RELEASE_NAMESPACE}

--- a/charts/rabbitmq-operator/values.yaml
+++ b/charts/rabbitmq-operator/values.yaml
@@ -22,12 +22,12 @@ rke2rabbitmqope:
     tag: "4.1.4-20250925"
     digest: ""
     pullSecrets: []
-  #credentialUpdaterImage:
-  #  registry: docker.io
-  #  repository: bitnami/rmq-default-credential-updater
-  #  tag: 1.0.5-debian-12-r6
-  #  digest: ""
-  #  pullSecrets: []
+  credentialUpdaterImage:
+    registry: docker.io
+    repository: sourcemation/rabbitmq-default-user-credential-updater
+    tag: "1.0.8-20250930"
+    digest: ""
+    pullSecrets: []
   clusterOperator:
     replicaCount: 2
     pdb:


### PR DESCRIPTION
New release:
* App version: 4.4.34
* Chart version: 0.1.17
* Immutable tags:

- sourcemation/rabbitmq-cluster-operator:2.16.1-20250922
- sourcemation/rabbitmq-4:4.1.4-20250925
- sourcemation/rabbitmq-default-user-credential-updater:1.0.8-20250930